### PR TITLE
Bugfix RFC 1123 header date format

### DIFF
--- a/src/main/java/com/emc/object/util/RestUtil.java
+++ b/src/main/java/com/emc/object/util/RestUtil.java
@@ -92,7 +92,7 @@ public final class RestUtil {
 
     public static final String DEFAULT_CONTENT_TYPE = TYPE_APPLICATION_OCTET_STREAM;
 
-    private static final String HEADER_FORMAT = "EEE, d MMM yyyy HH:mm:ss z";
+    private static final String HEADER_FORMAT = "EEE, dd MMM yyyy HH:mm:ss zzz";
     private static final ThreadLocal<DateFormat> headerFormat = new ThreadLocal<>();
     private static final ThreadLocal<CharsetEncoder> utf8Encoder = ThreadLocal.withInitial(StandardCharsets.UTF_8::newEncoder);
 

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -10,9 +10,16 @@
 	<logger name="org.apache.http.wire">
 		<level value="INFO" />
 	</logger>
-    <logger name="org.apache.http.headers">
-        <level value="INFO" />
-    </logger>
+ 	<logger name="org.apache.http.headers">
+		<level value="INFO" />
+	</logger>
+
+	<!-- Turn on for S3 signature logging -->
+	<!--
+	<logger name="com.emc.object.s3.S3SignerV2">
+		<level value="DEBUG"/>
+	</logger>
+	-->
 
 	<root>
 		<priority value="INFO" />


### PR DESCRIPTION
Fixes header date format for certain strict load balancers and proxies.  Some of these components were altering the Date header to conform to the standard, which invalidates the signature and causes requests to fail with a 403.  This fix makes sure the Data header adheres to the standard directly from the client, so it shouldn't be altered anywhere.