### PR TITLE
SDK-543: To support retention update added in ECS 3.6.

### DIFF
--- a/src/main/java/com/emc/object/s3/S3Client.java
+++ b/src/main/java/com/emc/object/s3/S3Client.java
@@ -390,6 +390,13 @@ public interface S3Client {
 
     AccessControlList getObjectAcl(GetObjectAclRequest request);
 
+    /**
+     * Extend retention <code>period</code>(seconds) on object <code>key</code> in bucket <code>bucketName</code>. NOTE:
+     * New retention period value can only be increased. That is, it can be the same as the current or greater value.
+     * If the new retention period value is -1, infinite retention applies on that object.
+     */
+    void extendRetentionPeriod(String bucketName, String key, Long period);
+
     ListMultipartUploadsResult listMultipartUploads(String bucketName);
 
     ListMultipartUploadsResult listMultipartUploads(ListMultipartUploadsRequest request);

--- a/src/main/java/com/emc/object/s3/S3Constants.java
+++ b/src/main/java/com/emc/object/s3/S3Constants.java
@@ -81,6 +81,7 @@ public final class S3Constants {
     public static final String PARAM_UPLOAD_ID_MARKER = "upload-id-marker";
     public static final String PARAM_VERSION_ID = "versionId";
     public static final String PARAM_VERSION_ID_MARKER = "version-id-marker";
+    public static final String PARAM_RETENTION_UPDATE = "retentionUpdate";
 
     public static final String PROPERTY_BUCKET_NAME = "com.emc.object.s3.bucketName";
     public static final String PROPERTY_OBJECT_KEY = "com.emc.object.s3.objectKey";

--- a/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
+++ b/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
@@ -677,6 +677,13 @@ public class S3JerseyClient extends AbstractJerseyClient implements S3Client {
     }
 
     @Override
+    public void extendRetentionPeriod(String bucketName, String key, Long period){
+        ObjectRequest request = new S3ObjectRequest(Method.PUT, bucketName, key, S3Constants.PARAM_RETENTION_UPDATE);
+        request.addCustomHeader(RestUtil.EMC_RETENTION_PERIOD, period);
+        executeAndClose(client, request);
+    }
+
+    @Override
     public ListMultipartUploadsResult listMultipartUploads(String bucketName) {
         return listMultipartUploads(new ListMultipartUploadsRequest(bucketName));
     }

--- a/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
+++ b/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
@@ -2175,6 +2175,33 @@ public class S3JerseyClientTest extends AbstractS3ClientTest {
     }
 
     @Test
+    public void testExtendObjectRetentionPeriod() throws Exception {
+        String key = "object-extend-retention";
+        String content = "Hello Extend Retention!";
+        Long retentionPeriod = 2L;
+        Long newRetentionPeriod = 5L;
+
+        String version = client.listDataNodes().getVersionInfo();
+        if (version.compareTo("3.6") < 0){
+            l4j.warn("Skip the extending retention period test. ECS test bed needs to be 3.6 or later, current version: " + version);
+            return;
+        }
+
+        String bucket = getTestBucket();
+        PutObjectRequest request = new PutObjectRequest(bucket, key, content);
+        request.withObjectMetadata(new S3ObjectMetadata().withRetentionPeriod(retentionPeriod));
+        client.putObject(request);
+        Assert.assertEquals(content, client.readObject(bucket, key, String.class));
+        Assert.assertEquals(retentionPeriod, client.getObject(bucket, key).getObjectMetadata().getRetentionPeriod());
+
+        client.extendRetentionPeriod(bucket, key, newRetentionPeriod);
+        //Verify retention period has been extended as expected.
+        Assert.assertEquals(newRetentionPeriod, client.getObject(bucket, key).getObjectMetadata().getRetentionPeriod());
+
+        Thread.sleep(5000); // allow retention to expire
+    }
+
+    @Test
     public void testPreSignedUrl() throws Exception {
         S3Client tempClient = new S3JerseyClient(new S3Config(new URI("https://s3.amazonaws.com")).withUseVHost(true)
                 .withIdentity("AKIAIOSFODNN7EXAMPLE").withSecretKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));

--- a/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
+++ b/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
@@ -2182,10 +2182,7 @@ public class S3JerseyClientTest extends AbstractS3ClientTest {
         Long newRetentionPeriod = 5L;
 
         String version = client.listDataNodes().getVersionInfo();
-        if (version.compareTo("3.6") < 0){
-            l4j.warn("Skip the extending retention period test. ECS test bed needs to be 3.6 or later, current version: " + version);
-            return;
-        }
+        Assume.assumeFalse("ECS test bed needs to be 3.6 or later, current version: " + version , version.compareTo("3.6") < 0);
 
         String bucket = getTestBucket();
         PutObjectRequest request = new PutObjectRequest(bucket, key, content);


### PR DESCRIPTION
New API com.emc.object.s3.S3Client.extendRetentionPeriod(String bucketName, String key, Long period) is added for this.