### PR TITLE
[SDK-551] Fix to eliminate flood of ?ping requests when clusters are unstable

### DIFF
--- a/src/main/java/com/emc/object/s3/S3Config.java
+++ b/src/main/java/com/emc/object/s3/S3Config.java
@@ -30,6 +30,8 @@ import com.emc.object.ObjectConfig;
 import com.emc.object.Protocol;
 import com.emc.object.util.ConfigUriProperty;
 import com.emc.rest.smart.Host;
+import com.emc.rest.smart.SmartClientFactory;
+import com.emc.rest.smart.SmartConfig;
 import com.emc.rest.smart.ecs.Vdc;
 
 import java.net.URI;
@@ -132,6 +134,12 @@ public class S3Config extends ObjectConfig<S3Config> {
     @Override
     public Host resolveHost() {
         return getVdcs().get(0).getHosts().get(0);
+    }
+
+    @Override
+    public SmartConfig toSmartConfig() {
+        // disable Apache client's retry - retries will be governed by our config and RetryFilter
+        return super.toSmartConfig().withProperty(SmartClientFactory.DISABLE_APACHE_RETRY, Boolean.TRUE);
     }
 
     @ConfigUriProperty

--- a/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
+++ b/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
@@ -184,10 +184,6 @@ public class S3JerseyClient extends AbstractJerseyClient implements S3Client {
             // S.C. - GEO-PINNING
             if (s3Config.isGeoPinningEnabled()) loadBalancer.withVetoRules(new GeoPinningRule());
 
-            // S.C. - RETRY CONFIG
-            if (s3Config.isRetryEnabled())
-                smartConfig.setProperty(SmartClientFactory.DISABLE_APACHE_RETRY, Boolean.TRUE);
-
             // S.C. - CHUNKED ENCODING (match ECS buffer size)
             smartConfig.setProperty(ClientConfig.PROPERTY_CHUNKED_ENCODING_SIZE, s3Config.getChunkedEncodingSize());
 


### PR DESCRIPTION
tweaked config to always disable the Apache retry mechanism, since retries are governed by our config and RetryFilter - this change will fix an issue where ?ping requests issued by the smart client are retried multiple times after a failure, which can exacerbate situations where the nodes are already overloaded