### PR TITLE
adjustments for some refactoring done in other branches

### DIFF
--- a/src/test/java/com/emc/object/s3/AbstractS3ClientTest.java
+++ b/src/test/java/com/emc/object/s3/AbstractS3ClientTest.java
@@ -86,7 +86,7 @@ public abstract class AbstractS3ClientTest extends AbstractClientTest {
     }
 
     @Override
-    protected void cleanUpBucket(String bucketName) throws Exception {
+    protected void cleanUpBucket(String bucketName) {
         if (client != null && client.bucketExists(bucketName)) {
             if (client.getBucketVersioning(bucketName).getStatus() != null) {
                 for (AbstractVersion version : client.listVersions(new ListVersionsRequest(bucketName).withEncodingType(EncodingType.url)).getVersions()) {
@@ -101,27 +101,23 @@ public abstract class AbstractS3ClientTest extends AbstractClientTest {
         }
     }
 
+    /**
+     * this should be the only hook method for generating an S3Config instance - if a test class needs any
+     * customizations to the config, override this method and call super, then make your customizations
+     */
     protected S3Config createS3Config() throws Exception {
         return s3ConfigFromProperties();
     }
 
-    protected S3Config s3ConfigFromProperties() throws Exception {
+    static S3Config s3ConfigFromProperties() throws Exception {
         Properties props = TestConfig.getProperties();
 
-        String accessKey = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_ACCESS_KEY);
-        String secretKey = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_SECRET_KEY);
-
-        S3Config s3Config = s3ConfigNetWorkSetting(props);
-        s3Config.withIdentity(accessKey).withSecretKey(secretKey);
-
-        return s3Config;
-    }
-
-    protected S3Config s3ConfigNetWorkSetting(Properties props) throws Exception {
         URI endpoint = new URI(TestConfig.getPropertyNotEmpty(props, TestProperties.S3_ENDPOINT));
         boolean enableVhost = Boolean.parseBoolean(props.getProperty(TestProperties.ENABLE_VHOST));
         boolean disableSmartClient = Boolean.parseBoolean(props.getProperty(TestProperties.DISABLE_SMART_CLIENT));
         String proxyUriStr = props.getProperty(TestProperties.PROXY_URI);
+        String accessKey = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_ACCESS_KEY);
+        String secretKey = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_SECRET_KEY);
 
         S3Config s3Config;
         if (enableVhost) {
@@ -143,6 +139,8 @@ public abstract class AbstractS3ClientTest extends AbstractClientTest {
 
         if (disableSmartClient)
             s3Config.setSmartClient(false);
+
+        s3Config.withIdentity(accessKey).withSecretKey(secretKey);
 
         return s3Config;
     }

--- a/src/test/java/com/emc/object/s3/S3TempCredentialsTest.java
+++ b/src/test/java/com/emc/object/s3/S3TempCredentialsTest.java
@@ -8,8 +8,6 @@ import com.emc.util.TestConfig;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
 import org.junit.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -19,18 +17,17 @@ import java.util.Date;
 import java.util.Properties;
 
 public class S3TempCredentialsTest extends S3JerseyClientTest {
-    private static final Logger log = LoggerFactory.getLogger(S3TempCredentialsTest.class);
     private static final String SESSION_TOKEN = "Cghuc190ZXN0MRIIaWFtX3VzZXIaFEFST0EzQjFGMDc0OUJFQkIzRDlFIiB1cm46ZWNzOmlhbTo6bnNfdGVzdDE6cm9sZS9yb2xlMSoUQVNJQUI1MTEzMzYwN0FBNzg1QjUyUE1hc3RlcktleVJlY29yZC0zZGE0ZTJlNmMyMGNiMzg2NDVlZTJlYjlkNWUxYzUxODJiYTBhYjQ3NWIxMDg4YWE5NDBmMzIyZTAyNWEzY2Q1OKXTrK2VL1IMZWNzLXN0cy10ZW1waL_l44QG";
 
-    protected S3Config s3ConfigFromProperties() throws Exception {
-
+    @Override
+    protected S3Config createS3Config() throws Exception {
         Properties props = TestConfig.getProperties();
 
         String accessKey = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_TEMP_ACCESS_KEY);
         String secretKey = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_TEMP_SECRET_KEY);
         String securityToken = TestConfig.getPropertyNotEmpty(props, TestProperties.S3_SECURITY_TOKEN);
 
-        S3Config s3Config = s3ConfigNetWorkSetting(props);
+        S3Config s3Config = super.createS3Config();
         s3Config.withIdentity(accessKey).withSecretKey(secretKey).withSessionToken(securityToken);
 
         return s3Config;
@@ -157,46 +154,42 @@ public class S3TempCredentialsTest extends S3JerseyClientTest {
 
     @Ignore
     @Test
-    public void testMultipleVdcs() throws Exception {
+    public void testMultipleVdcs() {
     }
 
     @Ignore
     @Test
-    public void testMpuAbortInMiddle() throws Exception {
+    public void testMpuAbortInMiddle() {
     }
 
     @Ignore
     @Test
-    public void testSetObjectAclRequestAcl() throws Exception {
+    public void testSetObjectAclRequestAcl() {
     }
 
     @Ignore
     @Test
-    public void testSetObjectAcl() throws Exception {
+    public void testSetObjectAcl() {
     }
 
     @Ignore
     @Test
     public void testCreateFilesystemBucket() {
-        super.testCreateFilesystemBucket();
     }
 
     @Ignore
     @Test
-    public void testSetBucketAclCanned() throws Exception {
-        super.testSetBucketAclCanned();
+    public void testSetBucketAclCanned() {
     }
 
     @Ignore
     @Test
-    public void testSetGetBucketAcl() throws Exception {
-        super.testSetGetBucketAcl();
+    public void testSetGetBucketAcl() {
     }
 
     @Ignore
     @Test
-    public void testExtendObjectRetentionPeriod() throws Exception {
-        super.testExtendObjectRetentionPeriod();
+    public void testExtendObjectRetentionPeriod() {
     }
 
     private S3Client getPresignDummyClient() throws URISyntaxException {

--- a/src/test/java/com/emc/object/s3/WriteTruncationTest.java
+++ b/src/test/java/com/emc/object/s3/WriteTruncationTest.java
@@ -10,8 +10,9 @@ import com.emc.object.util.FaultInjectionStream;
 import com.sun.jersey.api.client.ClientHandlerException;
 import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.log4j.Logger;
 import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
@@ -21,7 +22,7 @@ import java.net.URI;
 import java.util.Random;
 
 public class WriteTruncationTest {
-    public static final Logger log = Logger.getLogger(WriteTruncationTest.class);
+    public static final Logger log = LoggerFactory.getLogger(WriteTruncationTest.class);
 
     static final String BUCKET_NAME = "ecs-object-client-write-truncation-test";
     static final int OBJECT_RETENTION_PERIOD = 15; // 15 seconds


### PR DESCRIPTION
* Updated WriteTruncationTest to use slf4j (other test classes switched in a different branch)
* Refactored AbstractS3ClientTest.createS3Config as the only hook method for generating an S3Config instance - this also allows static reference to AbstractS3ClientTest.s3ConfigFromProperties