### PR TITLE
Fixed decoding of key names in URL-encoded list responses

### DIFF
--- a/src/main/java/com/emc/object/s3/bean/AbstractVersion.java
+++ b/src/main/java/com/emc/object/s3/bean/AbstractVersion.java
@@ -39,9 +39,12 @@ public abstract class AbstractVersion {
     private Date lastModified;
     private CanonicalUser owner;
 
-    //This method is called after all the properties (except IDREF) are unmarshalled for this object,
-    //but before this object is set to the parent object.
-    void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+    //NOTE: This method should only be called from the parent afterUnmarshal method.  This will not work as a direct
+    //      implementation of afterUnmarshal because the encodingType element comes at the very end of the XML packet,
+    //      and at the time this method would be called, that property is null, so we have no way of knowing whether the
+    //      response is encoded or not.  Thus, we prefix the name with an underscore, and must call this method from the
+    //      parent afterUnmarshal method.
+    void _afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
         if (parent instanceof UrlEncodable && ((UrlEncodable) parent).getEncodingType() == EncodingType.url) {
             // url-decode applicable values (key)
             key = RestUtil.urlDecode(key, false);

--- a/src/main/java/com/emc/object/s3/bean/CommonPrefix.java
+++ b/src/main/java/com/emc/object/s3/bean/CommonPrefix.java
@@ -41,9 +41,12 @@ public class CommonPrefix {
         this.prefix = prefix;
     }
 
-    //This method is called after all the properties (except IDREF) are unmarshalled for this object,
-    //but before this object is set to the parent object.
-    void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+    //NOTE: This method should only be called from the parent afterUnmarshal method.  This will not work as a direct
+    //      implementation of afterUnmarshal because the encodingType element comes at the very end of the XML packet,
+    //      and at the time this method would be called, that property is null, so we have no way of knowing whether the
+    //      response is encoded or not.  Thus, we prefix the name with an underscore, and must call this method from the
+    //      parent afterUnmarshal method.
+    void _afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
         if (parent instanceof UrlEncodable && ((UrlEncodable) parent).getEncodingType() == EncodingType.url) {
             // url-decode applicable values (prefix)
             prefix = RestUtil.urlDecode(prefix, false);

--- a/src/main/java/com/emc/object/s3/bean/ListMultipartUploadsResult.java
+++ b/src/main/java/com/emc/object/s3/bean/ListMultipartUploadsResult.java
@@ -47,8 +47,8 @@ public class ListMultipartUploadsResult {
     private String nextKeyMarker;
     private String nextUploadIdMarker;
     private boolean truncated;
-    private List<Upload> uploads = new ArrayList<Upload>();
-    private List<CommonPrefix> _commonPrefixes = new ArrayList<CommonPrefix>();
+    private List<Upload> uploads = new ArrayList<>();
+    private List<CommonPrefix> _commonPrefixes = new ArrayList<>();
 
     //This method is called after all the properties (except IDREF) are unmarshalled for this object,
     //but before this object is set to the parent object.
@@ -60,6 +60,8 @@ public class ListMultipartUploadsResult {
             delimiter = RestUtil.urlDecode(delimiter, false);
             keyMarker = RestUtil.urlDecode(keyMarker, false);
             nextKeyMarker = RestUtil.urlDecode(nextKeyMarker, false);
+            for (Upload upload : uploads) upload._afterUnmarshal(unmarshaller, this);
+            for (CommonPrefix prefix : _commonPrefixes) prefix._afterUnmarshal(unmarshaller, this);
         }
     }
 
@@ -173,7 +175,7 @@ public class ListMultipartUploadsResult {
 
     @XmlTransient
     public List<String> getCommonPrefixes() {
-        List<String> prefixes = new ArrayList<String>();
+        List<String> prefixes = new ArrayList<>();
         for (CommonPrefix prefix : _commonPrefixes) {
             prefixes.add(prefix.getPrefix());
         }

--- a/src/main/java/com/emc/object/s3/bean/ListObjectsResult.java
+++ b/src/main/java/com/emc/object/s3/bean/ListObjectsResult.java
@@ -45,8 +45,8 @@ public class ListObjectsResult implements UrlEncodable {
     private String marker;
     private String nextMarker;
     private boolean truncated;
-    private List<S3Object> objects = new ArrayList<S3Object>();
-    private List<CommonPrefix> _commonPrefixes = new ArrayList<CommonPrefix>();
+    private List<S3Object> objects = new ArrayList<>();
+    private List<CommonPrefix> _commonPrefixes = new ArrayList<>();
 
     //This method is called after all the properties (except IDREF) are unmarshalled for this object,
     //but before this object is set to the parent object.
@@ -58,6 +58,8 @@ public class ListObjectsResult implements UrlEncodable {
             delimiter = RestUtil.urlDecode(delimiter, false);
             marker = RestUtil.urlDecode(marker, false);
             nextMarker = RestUtil.urlDecode(nextMarker, false);
+            for (S3Object object : objects) object._afterUnmarshal(unmarshaller, this);
+            for (CommonPrefix prefix : _commonPrefixes) prefix._afterUnmarshal(unmarshaller, this);
         }
     }
 
@@ -153,7 +155,7 @@ public class ListObjectsResult implements UrlEncodable {
 
     @XmlTransient
     public List<String> getCommonPrefixes() {
-        List<String> prefixes = new ArrayList<String>();
+        List<String> prefixes = new ArrayList<>();
         for (CommonPrefix prefix : _commonPrefixes) {
             prefixes.add(prefix.getPrefix());
         }

--- a/src/main/java/com/emc/object/s3/bean/ListVersionsResult.java
+++ b/src/main/java/com/emc/object/s3/bean/ListVersionsResult.java
@@ -45,8 +45,8 @@ public class ListVersionsResult implements UrlEncodable {
     private String nextKeyMarker;
     private String nextVersionIdMarker;
     private boolean truncated;
-    private List<AbstractVersion> versions = new ArrayList<AbstractVersion>();
-    private List<CommonPrefix> _commonPrefixes = new ArrayList<CommonPrefix>();
+    private List<AbstractVersion> versions = new ArrayList<>();
+    private List<CommonPrefix> _commonPrefixes = new ArrayList<>();
 
     //This method is called after all the properties (except IDREF) are unmarshalled for this object,
     //but before this object is set to the parent object.
@@ -58,6 +58,8 @@ public class ListVersionsResult implements UrlEncodable {
             delimiter = RestUtil.urlDecode(delimiter, false);
             keyMarker = RestUtil.urlDecode(keyMarker, false);
             nextKeyMarker = RestUtil.urlDecode(nextKeyMarker, false);
+            for (AbstractVersion version : versions) version._afterUnmarshal(unmarshaller, this);
+            for (CommonPrefix prefix : _commonPrefixes) prefix._afterUnmarshal(unmarshaller, this);
         }
     }
 
@@ -171,7 +173,7 @@ public class ListVersionsResult implements UrlEncodable {
 
     @XmlTransient
     public List<String> getCommonPrefixes() {
-        List<String> prefixes = new ArrayList<String>();
+        List<String> prefixes = new ArrayList<>();
         for (CommonPrefix prefix : _commonPrefixes) {
             prefixes.add(prefix.getPrefix());
         }

--- a/src/main/java/com/emc/object/s3/bean/S3Object.java
+++ b/src/main/java/com/emc/object/s3/bean/S3Object.java
@@ -41,9 +41,12 @@ public class S3Object {
     private StorageClass storageClass;
     private CanonicalUser owner;
 
-    //This method is called after all the properties (except IDREF) are unmarshalled for this object,
-    //but before this object is set to the parent object.
-    void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+    //NOTE: This method should only be called from the parent afterUnmarshal method.  This will not work as a direct
+    //      implementation of afterUnmarshal because the encodingType element comes at the very end of the XML packet,
+    //      and at the time this method would be called, that property is null, so we have no way of knowing whether the
+    //      response is encoded or not.  Thus, we prefix the name with an underscore, and must call this method from the
+    //      parent afterUnmarshal method.
+    void _afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
         if (parent instanceof UrlEncodable && ((UrlEncodable) parent).getEncodingType() == EncodingType.url) {
             // url-decode applicable values (key)
             key = RestUtil.urlDecode(key, false);

--- a/src/main/java/com/emc/object/s3/bean/Upload.java
+++ b/src/main/java/com/emc/object/s3/bean/Upload.java
@@ -40,9 +40,12 @@ public class Upload {
     private StorageClass storageClass;
     private Date initiated;
 
-    //This method is called after all the properties (except IDREF) are unmarshalled for this object,
-    //but before this object is set to the parent object.
-    void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+    //NOTE: This method should only be called from the parent afterUnmarshal method.  This will not work as a direct
+    //      implementation of afterUnmarshal because the encodingType element comes at the very end of the XML packet,
+    //      and at the time this method would be called, that property is null, so we have no way of knowing whether the
+    //      response is encoded or not.  Thus, we prefix the name with an underscore, and must call this method from the
+    //      parent afterUnmarshal method.
+    void _afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
         if (parent instanceof UrlEncodable && ((UrlEncodable) parent).getEncodingType() == EncodingType.url) {
             // url-decode applicable values (key)
             key = RestUtil.urlDecode(key, false);

--- a/src/test/java/com/emc/object/s3/bean/ListObjectsResultTest.java
+++ b/src/test/java/com/emc/object/s3/bean/ListObjectsResultTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2015, EMC Corporation.
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * + Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ * + Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * + The name of EMC Corporation may not be used to endorse or promote
+ *   products derived from this software without specific prior written
+ *   permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.emc.object.s3.bean;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Unmarshaller;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+public class ListObjectsResultTest {
+    @Test
+    public void testMarshalling() throws Exception {
+        JAXBContext context = JAXBContext.newInstance(ListObjectsResult.class, CanonicalUser.class);
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>" +
+                "<ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">" +
+                "<IsTruncated>true</IsTruncated>" +
+                "<Marker>key2</Marker>" +
+                "<NextMarker>key3</NextMarker>" +
+                "<Contents>" +
+                "<ETag>&amp;quot;396fefef536d5ce46c7537ecf978a360&amp;quot;</ETag>" +
+                "<Key>sourcekey</Key>" +
+                "<LastModified>2050-01-01T00:00:00Z</LastModified>" +
+                "<Owner>" +
+                "<ID>ID12345</ID>" +
+                "<DisplayName>Foo Bar</DisplayName>" +
+                "</Owner>" +
+                "<Size>217</Size>" +
+                "<StorageClass>STANDARD</StorageClass>" +
+                "</Contents>" +
+                "<Contents>" +
+                "<ETag>&amp;quot;396fefef536d5ce46c7537ecf978a360&amp;quot;</ETag>" +
+                "<Key>key3</Key>" +
+                "<LastModified>2050-01-01T00:00:00Z</LastModified>" +
+                "<Owner>" +
+                "<ID>ID12345</ID>" +
+                "<DisplayName>Foo Bar</DisplayName>" +
+                "</Owner>" +
+                "<Size>217</Size>" +
+                "<StorageClass>STANDARD</StorageClass>" +
+                "</Contents>" +
+                "<Contents>" +
+                "<ETag>&amp;quot;396fefef536d5ce46c7537ecf978a360&amp;quot;</ETag>" +
+                "<Key>key%20with%20spaces</Key>" +
+                "<LastModified>2050-01-01T00:00:00Z</LastModified>" +
+                "<Owner>" +
+                "<ID>ID12345</ID>" +
+                "<DisplayName>Foo Bar</DisplayName>" +
+                "</Owner>" +
+                "<Size>124</Size>" +
+                "<StorageClass>STANDARD</StorageClass>" +
+                "</Contents>" +
+                "<Name>bucket</Name>" +
+                "<Prefix>my</Prefix>" +
+                "<Delimiter>/</Delimiter>" +
+                "<MaxKeys>1000</MaxKeys>" +
+                "<CommonPrefixes>" +
+                "<Prefix>photos/</Prefix>" +
+                "</CommonPrefixes>" +
+                "<CommonPrefixes>" +
+                "<Prefix>videos%20space/</Prefix>" +
+                "</CommonPrefixes>" +
+                "<EncodingType>url</EncodingType>" +
+                "</ListBucketResult>";
+
+        List<S3Object> objects = new ArrayList<>();
+
+        CanonicalUser owner = new CanonicalUser("ID12345", "Foo Bar");
+
+        S3Object object = new S3Object();
+        object.setKey("sourcekey");
+        object.setLastModified(new Date(2524608000000L));
+        object.setETag("&quot;396fefef536d5ce46c7537ecf978a360&quot;");
+        object.setSize(217L);
+        object.setOwner(owner);
+        object.setStorageClass(StorageClass.STANDARD);
+        objects.add(object);
+
+        object = new S3Object();
+        object.setKey("key3");
+        object.setLastModified(new Date(2524608000000L));
+        object.setETag("&quot;396fefef536d5ce46c7537ecf978a360&quot;");
+        object.setSize(217L);
+        object.setOwner(owner);
+        object.setStorageClass(StorageClass.STANDARD);
+        objects.add(object);
+
+        object = new S3Object();
+        object.setKey("key with spaces");
+        object.setLastModified(new Date(2524608000000L));
+        object.setETag("&quot;396fefef536d5ce46c7537ecf978a360&quot;");
+        object.setSize(124L);
+        object.setOwner(owner);
+        object.setStorageClass(StorageClass.STANDARD);
+        objects.add(object);
+
+        ListObjectsResult objectsResult = new ListObjectsResult();
+        objectsResult.setBucketName("bucket");
+        objectsResult.setPrefix("my");
+        objectsResult.setMarker("key2");
+        objectsResult.setNextMarker("key3");
+        objectsResult.setMaxKeys(1000);
+        objectsResult.setDelimiter("/");
+        objectsResult.setTruncated(true);
+        objectsResult.setObjects(objects);
+        objectsResult.set_commonPrefixes(Arrays.asList(new CommonPrefix("photos/"), new CommonPrefix("videos space/")));
+
+        // unmarshall and compare to object
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+        ListObjectsResult unmarshalledObject = (ListObjectsResult) unmarshaller.unmarshal(new StringReader(xml));
+        Assert.assertEquals(objectsResult.getBucketName(), unmarshalledObject.getBucketName());
+        Assert.assertEquals(objectsResult.getPrefix(), unmarshalledObject.getPrefix());
+        Assert.assertEquals(objectsResult.getMarker(), unmarshalledObject.getMarker());
+        Assert.assertEquals(objectsResult.getNextMarker(), unmarshalledObject.getNextMarker());
+        Assert.assertEquals(objectsResult.getMaxKeys(), unmarshalledObject.getMaxKeys());
+        Assert.assertEquals(objectsResult.getDelimiter(), unmarshalledObject.getDelimiter());
+        Assert.assertEquals(objectsResult.isTruncated(), unmarshalledObject.isTruncated());
+        Assert.assertEquals(objectsResult.getCommonPrefixes(), unmarshalledObject.getCommonPrefixes());
+        Assert.assertEquals(objectsResult.getObjects().size(), unmarshalledObject.getObjects().size());
+        for (int i = 0; i < objectsResult.getObjects().size(); i++) {
+            S3Object obj = objectsResult.getObjects().get(i);
+            S3Object unobj = unmarshalledObject.getObjects().get(i);
+            Assert.assertEquals(obj.getClass(), unobj.getClass());
+            Assert.assertEquals(obj.getKey(), unobj.getKey());
+            Assert.assertEquals(obj.getOwner(), unobj.getOwner());
+            Assert.assertEquals(obj.getLastModified(), unobj.getLastModified());
+            Assert.assertEquals(obj.getETag(), unobj.getETag());
+            Assert.assertEquals(obj.getSize(), unobj.getSize());
+            Assert.assertEquals(obj.getStorageClass(), unobj.getStorageClass());
+        }
+    }
+}

--- a/src/test/java/com/emc/object/s3/bean/ListVersionsResultTest.java
+++ b/src/test/java/com/emc/object/s3/bean/ListVersionsResultTest.java
@@ -63,6 +63,16 @@ public class ListVersionsResultTest {
                 "<DisplayName>Foo Bar</DisplayName>" +
                 "</Owner>" +
                 "</DeleteMarker>" +
+                "<DeleteMarker>" +
+                "<Key>key%20with%20spaces</Key>" +
+                "<VersionId>qDhprLU80sAlCFLu3DWgXAEDgKzWarn-HS_JU0TvYqs.</VersionId>" +
+                "<IsLatest>true</IsLatest>" +
+                "<LastModified>2050-01-01T00:00:00Z</LastModified>" +
+                "<Owner>" +
+                "<ID>ID12345</ID>" +
+                "<DisplayName>Foo Bar</DisplayName>" +
+                "</Owner>" +
+                "</DeleteMarker>" +
                 "<Version>" +
                 "<Key>sourcekey</Key>" +
                 "<VersionId>wxxQ7ezLaL5JN2Sislq66Syxxo0k7uHTUpb9qiiMxNg.</VersionId>" +
@@ -89,21 +99,43 @@ public class ListVersionsResultTest {
                 "</Owner>" +
                 "<StorageClass>STANDARD</StorageClass>" +
                 "</Version>" +
+                "<Version>" +
+                "<Key>key%20with%20spaces</Key>" +
+                "<VersionId>d-d309mfjFri40QYukDozqBt3UmoQ0DBsVqmcMV16OI.</VersionId>" +
+                "<IsLatest>false</IsLatest>" +
+                "<LastModified>2050-01-01T00:00:00Z</LastModified>" +
+                "<ETag>&amp;quot;396fefef536d5ce46c7537ecf978a360&amp;quot;</ETag>" +
+                "<Size>124</Size>" +
+                "<Owner>" +
+                "<ID>ID12345</ID>" +
+                "<DisplayName>Foo Bar</DisplayName>" +
+                "</Owner>" +
+                "<StorageClass>STANDARD</StorageClass>" +
+                "</Version>" +
                 "<CommonPrefixes>" +
                 "<Prefix>photos/</Prefix>" +
                 "</CommonPrefixes>" +
                 "<CommonPrefixes>" +
-                "<Prefix>videos/</Prefix>" +
+                "<Prefix>videos%20space/</Prefix>" +
                 "</CommonPrefixes>" +
+                "<EncodingType>url</EncodingType>" +
                 "</ListVersionsResult>";
 
-        List<AbstractVersion> versions = new ArrayList<AbstractVersion>();
+        List<AbstractVersion> versions = new ArrayList<>();
 
         CanonicalUser owner = new CanonicalUser("ID12345", "Foo Bar");
 
         AbstractVersion version = new DeleteMarker();
         version.setKey("sourcekey");
         version.setVersionId("qDhprLU80sAlCFLu2DWgXAEDgKzWarn-HS_JU0TvYqs.");
+        version.setLatest(true);
+        version.setLastModified(new Date(2524608000000L));
+        version.setOwner(owner);
+        versions.add(version);
+
+        version = new DeleteMarker();
+        version.setKey("key with spaces");
+        version.setVersionId("qDhprLU80sAlCFLu3DWgXAEDgKzWarn-HS_JU0TvYqs.");
         version.setLatest(true);
         version.setLastModified(new Date(2524608000000L));
         version.setOwner(owner);
@@ -131,6 +163,17 @@ public class ListVersionsResultTest {
         ((Version) version).setStorageClass(StorageClass.STANDARD);
         versions.add(version);
 
+        version = new Version();
+        version.setKey("key with spaces");
+        version.setVersionId("d-d309mfjFri40QYukDozqBt3UmoQ0DBsVqmcMV16OI.");
+        version.setLatest(false);
+        version.setLastModified(new Date(2524608000000L));
+        ((Version) version).setETag("&quot;396fefef536d5ce46c7537ecf978a360&quot;");
+        ((Version) version).setSize(124L);
+        version.setOwner(owner);
+        ((Version) version).setStorageClass(StorageClass.STANDARD);
+        versions.add(version);
+
         ListVersionsResult object = new ListVersionsResult();
         object.setBucketName("bucket");
         object.setPrefix("my");
@@ -142,7 +185,7 @@ public class ListVersionsResultTest {
         object.setDelimiter("/");
         object.setTruncated(true);
         object.setVersions(versions);
-        object.set_commonPrefixes(Arrays.asList(new CommonPrefix("photos/"), new CommonPrefix("videos/")));
+        object.set_commonPrefixes(Arrays.asList(new CommonPrefix("photos/"), new CommonPrefix("videos space/")));
 
         // unmarshall and compare to object
         Unmarshaller unmarshaller = context.createUnmarshaller();


### PR DESCRIPTION
fixed decoding of key names in ListObjectsResult, ListVersionsResult, and ListMultipartUploadsResult for URL-encoded API responses