### PR TITLE
More fixes for SDK-575

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-api:1.7.32'
     testImplementation 'junit:junit:4.13.2'
     testRuntimeOnly 'org.slf4j:jcl-over-slf4j:1.7.32'
-    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+    testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
 }
 
 allprojects {

--- a/src/main/java/com/emc/object/s3/S3SignerV4.java
+++ b/src/main/java/com/emc/object/s3/S3SignerV4.java
@@ -140,7 +140,7 @@ public class S3SignerV4 extends S3Signer {
         else {
             canonicalRequest.append(HASHED_EMPTY_PAYLOAD);
         }
-        log.debug("CanonicalRequest: {}" + canonicalRequest);
+        log.debug("CanonicalRequest: {}", canonicalRequest);
         return canonicalRequest.toString();
     }
 

--- a/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
+++ b/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
@@ -2773,7 +2773,10 @@ public class S3JerseyClientTest extends AbstractS3ClientTest {
                 future.get();
             } catch (Throwable e) {
                 while (e.getCause() != null && e.getCause() != e) e = e.getCause();
-                if (e instanceof SocketException && e.getMessage().startsWith("Broken pipe")) continue;
+                if (e instanceof SocketException && (e.getMessage().startsWith("Broken pipe")
+                        || e.getMessage().startsWith("Connection reset by peer")
+                        || e.getMessage().startsWith("Software caused connection abort")))
+                    continue;
                 if (!(e instanceof S3Exception)) throw new RuntimeException(e);
                 S3Exception se = (S3Exception) e;
                 if (!"NoSuchUpload".equals(se.getErrorCode()) && !"NoSuchKey".equals(se.getErrorCode()))

--- a/src/test/java/com/emc/object/s3/S3JerseyUrlConnectionV4Test.java
+++ b/src/test/java/com/emc/object/s3/S3JerseyUrlConnectionV4Test.java
@@ -2,10 +2,17 @@ package com.emc.object.s3;
 
 import com.emc.object.ObjectConfig;
 import com.emc.object.s3.jersey.S3JerseyClient;
+import com.emc.object.s3.request.PutObjectRequest;
+import com.emc.util.RandomInputStream;
 import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.InputStream;
 import java.net.URI;
 
-public class S3JerseyUrlConnectionV4Test extends S3JerseyUrlConnectionTest {
+public class S3JerseyUrlConnectionV4Test extends S3JerseyClientV4Test {
     @Override
     protected String getTestBucketPrefix() {
         return "s3-url-connection-v4-test";
@@ -22,5 +29,29 @@ public class S3JerseyUrlConnectionV4Test extends S3JerseyUrlConnectionTest {
             System.setProperty("http.proxyPort", "" + proxyUri.getPort());
         }
         return new S3JerseyClient(config, new URLConnectionClientHandler());
+    }
+
+    @Ignore // only run this test against a co-located ECS!
+    @Test
+    public void testVeryLargeWrite() throws Exception {
+        String key = "very-large-object";
+        long size = (long) Integer.MAX_VALUE + 102400;
+        InputStream content = new RandomInputStream(size);
+        S3ObjectMetadata metadata = new S3ObjectMetadata().withContentLength(size);
+        PutObjectRequest request = new PutObjectRequest(getTestBucket(), key, content).withObjectMetadata(metadata);
+        client.putObject(request);
+
+        Assert.assertEquals(size, client.getObjectMetadata(getTestBucket(), key).getContentLength().longValue());
+    }
+
+    @Ignore // only run this test against a co-located ECS!
+    @Test
+    public void testVeryLargeChunkedWrite() throws Exception {
+        String key = "very-large-chunked-object";
+        long size = (long) Integer.MAX_VALUE + 102400;
+        InputStream content = new RandomInputStream(size);
+        client.putObject(getTestBucket(), key, content, null);
+
+        Assert.assertEquals(size, client.getObjectMetadata(getTestBucket(), key).getContentLength().longValue());
     }
 }

--- a/src/test/java/com/emc/object/s3/Sdk238V4Test.java
+++ b/src/test/java/com/emc/object/s3/Sdk238V4Test.java
@@ -15,12 +15,17 @@ public class Sdk238V4Test extends Sdk238Test{
     @Override
     @Test
     public void testTrailingSlash() throws Exception {
+        S3Config s3Config = AbstractS3ClientTest.s3ConfigFromProperties();
         Sdk238V4Test.TestClient client = new Sdk238V4Test.TestClient(AbstractS3ClientTest.s3ConfigFromProperties());
 
         String bucket = "test-trailing-slash-v4";
         client.createBucket(bucket);
         try {
-            Assert.assertEquals("/" + bucket, client.getLastUri().getPath());
+            if (s3Config.isUseVHost()) {
+                Assert.assertEquals("/", client.getLastUri().getPath());
+            } else {
+                Assert.assertEquals("/" + bucket, client.getLastUri().getPath());
+            }
         } finally {
             client.deleteBucket(bucket);
         }

--- a/src/test/java/com/emc/object/s3/Sdk238V4Test.java
+++ b/src/test/java/com/emc/object/s3/Sdk238V4Test.java
@@ -16,7 +16,7 @@ public class Sdk238V4Test extends Sdk238Test{
     @Test
     public void testTrailingSlash() throws Exception {
         S3Config s3Config = AbstractS3ClientTest.s3ConfigFromProperties();
-        Sdk238V4Test.TestClient client = new Sdk238V4Test.TestClient(AbstractS3ClientTest.s3ConfigFromProperties());
+        Sdk238V4Test.TestClient client = new Sdk238V4Test.TestClient(s3Config);
 
         String bucket = "test-trailing-slash-v4";
         client.createBucket(bucket);

--- a/src/test/java/com/emc/object/s3/bean/QueryObjectResultTest.java
+++ b/src/test/java/com/emc/object/s3/bean/QueryObjectResultTest.java
@@ -109,7 +109,7 @@ public class QueryObjectResultTest {
 
         result.setObjects(objects);
 
-        List<String> prefixGroups = new ArrayList<String>(Arrays.asList("prefix/"));
+        List<String> prefixGroups = Arrays.asList("prefix/");
         result.setPrefixGroups(prefixGroups);
 
         // unmarshall and compare to object


### PR DESCRIPTION
* Update log4j.
* Fix Sdk238V4Test.testTrailingSlash() test failure.
T.B.D. investigate other failures reported by ETD test and make fix.