### PR TITLE
bugfix - LFU with zero-sized stream

### DIFF
--- a/src/main/java/com/emc/object/s3/LargeFileUploader.java
+++ b/src/main/java/com/emc/object/s3/LargeFileUploader.java
@@ -84,7 +84,7 @@ public class LargeFileUploader implements Runnable, ProgressListener {
     private final InputStream stream;
     private final LargeFileMultipartSource multipartSource;
 
-    private long fullSize;
+    private long fullSize = -1;
     private final AtomicLong bytesTransferred = new AtomicLong();
     private String eTag;
     private String versionId;
@@ -553,7 +553,7 @@ public class LargeFileUploader implements Runnable, ProgressListener {
         } else if (stream != null) {
 
             // make sure size is set
-            if (fullSize <= 0)
+            if (fullSize < 0)
                 throw new IllegalArgumentException("size must be specified for stream");
 
             // If resuming from raw stream, make sure skipped parts are consumed from source stream


### PR DESCRIPTION
fixed bug in LFU with zero-sized streams (empty objects) - this use case would be when calling code always uses LFU to upload objects (so it handles MPU or single-put automatically), and there may be a case where the source data is coming from a stream, but is empty (zero bytes)