### PR TITLE
Feature sdk 574 copy range

### DIFF
--- a/src/main/java/com/emc/object/s3/S3Client.java
+++ b/src/main/java/com/emc/object/s3/S3Client.java
@@ -471,10 +471,9 @@ public interface S3Client {
     ObjectLockRetention getObjectRetention(GetObjectRetentionRequest request);
 
     /**
-     * Upload Part - Copy API from S3, would be inefficient because there can be up to 220+ parts per object.
-     * This would cause a lot of transaction overhead to create all the part objects and potentially create a lot of partial garbage to collect if we have to deep copy the parts.
-     * This API can source from multiple objects and reference ranges inside those objects.
-     * It can work though with many Internet proxy servers, web servers (ECS included), and load balancers which have a limit on HTTP headers.
+     * This API is an ECS extension API. 
+     * IN addition to standard UploadPartCopy, it can source from multiple objects and reference ranges inside those objects. 
+     * And it can work though with many Internet proxy servers, web servers (ECS included), and load balancers which may have a limit on HTTP headers.
      */
     CopyRangeResult copyRange(CopyRangeRequest request);
   

--- a/src/main/java/com/emc/object/s3/S3Client.java
+++ b/src/main/java/com/emc/object/s3/S3Client.java
@@ -463,4 +463,6 @@ public interface S3Client {
      */
     ObjectLockRetention getObjectRetention(GetObjectRetentionRequest request);
 
+    CopyRangeResult copyRange(CopyRangeRequest request);
+
 }

--- a/src/main/java/com/emc/object/s3/bean/CopyRange.java
+++ b/src/main/java/com/emc/object/s3/bean/CopyRange.java
@@ -21,7 +21,7 @@ public class CopyRange {
      */
     private Segments segments;
 
-    @XmlElement(name = "ContentType")
+    @XmlElement(name = "ContentType", required = true)
     public String getContentType() {
         return contentType;
     }
@@ -30,7 +30,7 @@ public class CopyRange {
         this.contentType = contentType;
     }
 
-    @XmlElement(name = "Segments")
+    @XmlElement(name = "Segments", required = true)
     public Segments getSegments() {
         return segments;
     }

--- a/src/main/java/com/emc/object/s3/bean/CopyRange.java
+++ b/src/main/java/com/emc/object/s3/bean/CopyRange.java
@@ -1,0 +1,52 @@
+package com.emc.object.s3.bean;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ *  Container for the multi copy range request
+ */
+@XmlRootElement(name = "CopyRangeRequest")
+public class CopyRange {
+
+    /**
+     * This element defines the content type of target object
+     * @valid none
+     */
+    private String contentType;
+
+    /**
+     * This element defines segments the target object will copy from
+     * @valid none
+     */
+    private Segments segments;
+
+    @XmlElement(name = "ContentType")
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    @XmlElement(name = "Segments")
+    public Segments getSegments() {
+        return segments;
+    }
+
+    public void setSegments(Segments segments) {
+        this.segments = segments;
+    }
+
+    public CopyRange withContentType(String contentType) {
+        setContentType(contentType);
+        return this;
+    }
+
+    public CopyRange withSegments(Segments segments) {
+        setSegments(segments);
+        return this;
+    }
+
+}

--- a/src/main/java/com/emc/object/s3/bean/CopyRangeResult.java
+++ b/src/main/java/com/emc/object/s3/bean/CopyRangeResult.java
@@ -1,0 +1,15 @@
+package com.emc.object.s3.bean;
+
+import com.emc.object.ObjectResponse;
+import com.emc.object.util.RestUtil;
+
+import javax.xml.bind.annotation.XmlTransient;
+
+public class CopyRangeResult extends ObjectResponse {
+
+    @XmlTransient
+    public String getETag() {
+        return firstHeader(RestUtil.HEADER_ETAG);
+    }
+
+}

--- a/src/main/java/com/emc/object/s3/bean/Segment.java
+++ b/src/main/java/com/emc/object/s3/bean/Segment.java
@@ -10,7 +10,7 @@ public class Segment {
      * This element defines the path of source object
      * @valid none
      */
-    @XmlElement(name = "Path")
+    @XmlElement(name = "Path", required = true)
     private String path;
 
     /**

--- a/src/main/java/com/emc/object/s3/bean/Segment.java
+++ b/src/main/java/com/emc/object/s3/bean/Segment.java
@@ -1,0 +1,58 @@
+package com.emc.object.s3.bean;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "Segment")
+public class Segment {
+
+    /**
+     * This element defines the path of source object
+     * @valid none
+     */
+    @XmlElement(name = "Path")
+    private String path;
+
+    /**
+     * This element defines the etag of source object
+     * @valid none
+     */
+    @XmlElement (name = "Etag")
+    private String etag;
+
+    /**
+     * This element defines the range copy from source object
+     * @valid none
+     */
+    @XmlElement (name = "Range")
+    private String range;
+
+    /**
+     * algorithm object was encrypted
+     */
+    @XmlElement (name = "SseCAlg")
+    private String sse_c_alg;
+
+    /**
+     * base64-encoded encryption key for the object
+     */
+    @XmlElement (name = "SseCKey")
+    private String sse_c_key;
+
+    /**
+     * base64-encoded 128-bit MD5 digest of the encryption key
+     */
+    @XmlElement (name = "SseCKeyMD5")
+    private String sse_c_key_md5;
+
+    public Segment() {}
+
+    public Segment(String path, String etag, String range, String sse_c_alg, String sse_c_key, String sse_c_key_md5) {
+        this.path = path;
+        this.etag = etag;
+        this.range = range;
+        this.sse_c_alg = sse_c_alg;
+        this.sse_c_key = sse_c_key;
+        this.sse_c_key_md5 = sse_c_key_md5;
+    }
+}

--- a/src/main/java/com/emc/object/s3/bean/Segments.java
+++ b/src/main/java/com/emc/object/s3/bean/Segments.java
@@ -1,0 +1,25 @@
+package com.emc.object.s3.bean;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement(name = "Segments")
+public class Segments {
+
+    private List<Segment> segmentEntries;
+
+    @XmlElement(name = "Segment")
+    public List<Segment> getSegmentEntries() {
+        return segmentEntries;
+    }
+
+    public void setSegmentEntries(List<Segment> segmentEntries) {
+        this.segmentEntries = segmentEntries;
+    }
+
+    public Segments withSegmentEntries(List<Segment> segmentEntries) {
+        setSegmentEntries(segmentEntries);
+        return this;
+    }
+}

--- a/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
+++ b/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
@@ -800,15 +800,23 @@ public class S3JerseyClient extends AbstractJerseyClient implements S3Client {
     }
 
     @Override
+    public CopyRangeResult copyRange(CopyRangeRequest request) {
+        CopyRangeResult result = new CopyRangeResult();
+        fillResponseEntity(result, executeAndClose(client, request));
+        return result;
+    }
+
+    @Override
     protected <T> T executeRequest(Client client, ObjectRequest request, Class<T> responseType) {
         ClientResponse response = executeRequest(client, request);
+
         try {
             T responseEntity = response.getEntity(responseType);
             fillResponseEntity(responseEntity, response);
             return responseEntity;
         } catch (ClientHandlerException e) {
 
-            // some S3 responses return a 200 right away, but may fail and include an error XML package instead of the
+            // some S3 responses ret12eurn a 200 right away, but may fail and include an error XML package instead of the
             // expected entity. check for that here.
             try {
                 throw ErrorFilter.parseErrorResponse(new StringReader(response.getEntity(String.class)), response.getStatus());

--- a/src/main/java/com/emc/object/s3/request/CopyObjectRequest.java
+++ b/src/main/java/com/emc/object/s3/request/CopyObjectRequest.java
@@ -54,8 +54,6 @@ public class CopyObjectRequest extends S3ObjectRequest {
     private AccessControlList acl;
     private CannedAcl cannedAcl;
 
-    private String copyMode;
-
     public CopyObjectRequest(String sourceBucketName, String sourceKey, String bucketName, String key) {
         super(Method.PUT, bucketName, key, null);
         this.sourceBucketName = sourceBucketName;
@@ -85,8 +83,7 @@ public class CopyObjectRequest extends S3ObjectRequest {
         }
         if (acl != null) headers.putAll(acl.toHeaders());
         if (cannedAcl != null) RestUtil.putSingle(headers, S3Constants.AMZ_ACL, cannedAcl.getHeaderValue());
-        if (copyMode != null)
-            RestUtil.putSingle(headers, RestUtil.EMC_COPY_MODE, copyMode);
+
         return headers;
     }
 
@@ -178,14 +175,6 @@ public class CopyObjectRequest extends S3ObjectRequest {
         this.cannedAcl = cannedAcl;
     }
 
-    public String getCopyMode() {
-        return copyMode;
-    }
-
-    public void setCopyMode(String copyMode) {
-        this.copyMode = copyMode;
-    }
-
     public CopyObjectRequest withSourceVersionId(String sourceVersionId) {
         setSourceVersionId(sourceVersionId);
         return this;
@@ -226,8 +215,4 @@ public class CopyObjectRequest extends S3ObjectRequest {
         return this;
     }
 
-    public CopyObjectRequest withCopyMode(String copyMode) {
-        setCopyMode(copyMode);
-        return this;
-    }
 }

--- a/src/main/java/com/emc/object/s3/request/CopyRangeRequest.java
+++ b/src/main/java/com/emc/object/s3/request/CopyRangeRequest.java
@@ -1,0 +1,107 @@
+package com.emc.object.s3.request;
+
+import com.emc.object.EntityRequest;
+import com.emc.object.Method;
+import com.emc.object.s3.S3Constants;
+import com.emc.object.s3.bean.CopyRange;
+import com.emc.object.util.RestUtil;
+
+import java.util.List;
+import java.util.Map;
+
+public class CopyRangeRequest extends S3ObjectRequest implements EntityRequest {
+
+    private String contentMd5;
+    private String copyMode;
+    private String multiPartCopy;
+    private CopyRange copyRange;
+
+    public CopyRangeRequest(String bucketName, String key) {
+        super(Method.PUT, bucketName, key, null);
+    }
+
+    @Override
+    public Map<String, List<Object>> getHeaders() {
+        Map<String, List<Object>> headers = super.getHeaders();
+        if (contentMd5 != null)
+            RestUtil.putSingle(headers, RestUtil.HEADER_CONTENT_MD5, contentMd5);
+        if (copyMode != null)
+            RestUtil.putSingle(headers, RestUtil.EMC_COPY_MODE, copyMode);
+        if (multiPartCopy != null)
+            RestUtil.putSingle(headers, RestUtil.EMC_MULTIPART_COPY, multiPartCopy);
+       return headers;
+    }
+
+    @Override
+    public String getContentType() {
+        return RestUtil.TYPE_APPLICATION_XML;
+    }
+
+    @Override
+    public Long getContentLength() {
+        return null; // assume chunked encoding or buffering
+    }
+
+    @Override
+    public boolean isChunkable() {
+        return true;
+    }
+
+    @Override
+    public Object getEntity() {
+        return copyRange;
+    }
+
+    public String getContentMd5() {
+        return contentMd5;
+    }
+
+    public void setContentMd5(String contentMd5) {
+        this.contentMd5 = contentMd5;
+    }
+
+    public String getCopyMode() {
+        return copyMode;
+    }
+
+    public void setCopyMode(String copyMode) {
+        this.copyMode = copyMode;
+    }
+
+    public String getMultiPartCopy() {
+        return multiPartCopy;
+    }
+
+    public void setMultiPartCopy(String multiPartCopy) {
+        this.multiPartCopy = multiPartCopy;
+    }
+
+    public CopyRange getCopyRange() {
+        return copyRange;
+    }
+
+    public void setCopyRange(CopyRange copyRange) {
+        this.copyRange = copyRange;
+    }
+
+    public CopyRangeRequest withContentMd5(String contentMd5) {
+        setContentMd5(contentMd5);
+        return this;
+    }
+
+    public CopyRangeRequest withCopyMode(String copyMode) {
+        setCopyMode(copyMode);
+        return this;
+    }
+
+    public CopyRangeRequest withMultiPartCopy(String multiPartCopy) {
+        setMultiPartCopy(multiPartCopy);
+        return this;
+    }
+
+    public CopyRangeRequest withCopyRange(CopyRange copyRange) {
+        setCopyRange(copyRange);
+        return this;
+    }
+
+}

--- a/src/main/java/com/emc/object/util/RestUtil.java
+++ b/src/main/java/com/emc/object/util/RestUtil.java
@@ -77,6 +77,7 @@ public final class RestUtil {
     public static final String EMC_RETENTION_POLICY = EMC_PREFIX + "retention-policy";
     public static final String EMC_METADATA_SEARCH = EMC_PREFIX + "metadata-search";
     public static final String EMC_COPY_MODE = EMC_PREFIX + "copy-mode";
+    public final static String EMC_MULTIPART_COPY = EMC_PREFIX + "multipart-copy";
 
     public static final String TYPE_APPLICATION_OCTET_STREAM = "application/octet-stream";
     public static final String TYPE_APPLICATION_XML = "application/xml";

--- a/src/test/java/com/emc/object/s3/S3EncryptionClientBasicTest.java
+++ b/src/test/java/com/emc/object/s3/S3EncryptionClientBasicTest.java
@@ -31,7 +31,6 @@ import com.emc.codec.encryption.BasicKeyProvider;
 import com.emc.codec.encryption.EncryptionConstants;
 import com.emc.codec.encryption.EncryptionUtil;
 import com.emc.object.EncryptionConfig;
-import com.emc.object.Range;
 import com.emc.object.s3.bean.*;
 import com.emc.object.s3.jersey.FaultInjectionFilter;
 import com.emc.object.s3.jersey.S3EncryptionClient;
@@ -49,17 +48,16 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyPair;
-import java.security.MessageDigest;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -668,5 +666,4 @@ public class S3EncryptionClientBasicTest extends S3JerseyClientTest {
         Assert.assertEquals("The correct number of versions were NOT returned", 10, size);
         Assert.assertEquals("should be 5 pages", 5, requestCount);
     }
-
 }

--- a/src/test/java/com/emc/object/s3/S3EncryptionClientBasicTest.java
+++ b/src/test/java/com/emc/object/s3/S3EncryptionClientBasicTest.java
@@ -557,6 +557,10 @@ public class S3EncryptionClientBasicTest extends S3JerseyClientTest {
     public void testPreSignedUrlHeaderOverrides() throws Exception {
     }
 
+    @Override
+    public void testCopyRangeAPI() {
+    }
+
     private class ErrorStream extends FilterInputStream {
         private int callCount = 0;
 

--- a/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
+++ b/src/test/java/com/emc/object/s3/S3JerseyClientTest.java
@@ -1418,11 +1418,11 @@ public class S3JerseyClientTest extends AbstractS3ClientTest {
         for (MultipartPart part : mpp) {
             //this does NOT assume that the list comes back in sequential order
             if (part.getPartNumber() == 1) {
-                Assert.assertEquals(mp1.getRawETag(), part.getRawETag());
+                Assert.assertEquals(mp1.getRawETag(), mpp.get(0).getRawETag());
             } else if (part.getPartNumber() == 2) {
-                Assert.assertEquals(mp2.getRawETag(), part.getRawETag());
+                Assert.assertEquals(mp2.getRawETag(), mpp.get(1).getRawETag());
             } else if (part.getPartNumber() == 3) {
-                Assert.assertEquals(mp3.getRawETag(), part.getRawETag());
+                Assert.assertEquals(mp3.getRawETag(), mpp.get(2).getRawETag());
             } else {
                 Assert.fail("Unknown Part number: " + part.getPartNumber());
             }
@@ -2815,7 +2815,7 @@ public class S3JerseyClientTest extends AbstractS3ClientTest {
     @Test
     public void testCopyRangeAPI() {
         Assume.assumeTrue("ECS version must be at least 3.6.2", ecsVersion != null && ecsVersion.compareTo("3.6.2") >= 0);
-        Assume.assumeFalse("Copy range API is not supported with IAM user.", testIAM);
+        Assume.assumeFalse("Copy range API is not supported with IAM user.", isIamUser);
 
         String bucketName = getTestBucket(),
                 key1 = "TestObject_source_1",


### PR DESCRIPTION
After further research, I findthat this header 'x-emc-copy-mode' would only work in Multi-Part Copy API (Copy Range). So first I remove the header in Copy Object request, and wouldn't anymore add it in Copy Part request. 
Based on communication with object heads dev, ECS extension API: Copy Range, which is not an S3 API, is introduced. It's like a general need by users, not only DataDomain.
S3's Upload Part - Copy API might have these two problems. 1) when we have tons of parts in objects, it would cause a lot of transaction overhead to create all the part objects and have a lot of partial GC in deep copy mode. 2) The "recipe" should somehow put into the body of the request to bypass the server limits on HTTP headers.
Here is the design doc, https://confluence.cec.lab.emc.com/display/ECS/Copy+Range+API+Design.