### PR TITLE
[SDK-615] LargeFileUploader throws CancellationException when paused

### DIFF
--- a/src/main/java/com/emc/object/s3/LargeFileUploader.java
+++ b/src/main/java/com/emc/object/s3/LargeFileUploader.java
@@ -435,8 +435,11 @@ public class LargeFileUploader implements Runnable, ProgressListener {
                 try {
                     resumeContext.getUploadedParts().put(future.get().getPartNumber(), future.get());
                 } catch (ExecutionException e) { // unfortunately, we can't just catch CancellationException here
+                    // get the root cause
+                    Throwable t = e;
+                    while (t.getCause() != null && t.getCause() != t) t = t.getCause();
                     // CancellationException is only thrown when we are terminated early - cancelled tasks will just be ignored
-                    if (e.getCause() == null || !(e.getCause() instanceof CancellationException)) throw e;
+                    if (!(t instanceof CancellationException)) throw e;
                 }
             }
 


### PR DESCRIPTION
In some situations (you provide an ExecutorService, call `uploadAsync()` and then `upload.pause()`), LFU will throw a CancellationException to calling code.

This fix makes LargeFileUploader pull the root cause exception when checking for CancellationException from futures, as some executors may wrap the exception multiple times.