### PR TITLE
bug fixes for ECS 3.8 changes

### DIFF
--- a/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
+++ b/src/main/java/com/emc/object/s3/jersey/S3JerseyClient.java
@@ -389,7 +389,8 @@ public class S3JerseyClient extends AbstractJerseyClient implements S3Client {
         try {
             return executeRequest(client, request, LifecycleConfiguration.class);
         } catch (S3Exception e) {
-            if ("NoSuchBucketPolicy".equals(e.getErrorCode())) return null;
+            if ("NoSuchBucketPolicy".equals(e.getErrorCode()) || "NoSuchLifecycleConfiguration".equals(e.getErrorCode()))
+                return null;
             throw e;
         }
     }

--- a/src/test/java/com/emc/object/s3/S3EncryptionClientBasicTest.java
+++ b/src/test/java/com/emc/object/s3/S3EncryptionClientBasicTest.java
@@ -529,6 +529,11 @@ public class S3EncryptionClientBasicTest extends S3JerseyClientTest {
 
     @Ignore
     @Override
+    public void testDeleteObjectPreconditions() {
+    }
+
+    @Ignore
+    @Override
     public void testCopyObjectSelf() {
     }
 

--- a/src/test/java/com/emc/object/s3/S3MetadataSearchTest.java
+++ b/src/test/java/com/emc/object/s3/S3MetadataSearchTest.java
@@ -46,10 +46,10 @@ public class S3MetadataSearchTest extends AbstractS3ClientTest {
 
     @Test
     public void testListSystemMetadataSearchKeys() throws Exception {
-        boolean is37OrLater = ecsVersion != null && ecsVersion.compareTo("3.7") >= 0;
+        boolean is37x = ecsVersion != null && ecsVersion.matches("3\\.7\\..*");
         MetadataSearchKey[] expectedIndexableKeys;
         MetadataSearchKey[] expectedOptionalAttributes;
-        if (!is37OrLater) {
+        if (!is37x) {
             expectedIndexableKeys = new MetadataSearchKey[]{
                     new MetadataSearchKey("CreateTime", MetadataSearchDatatype.datetime),
                     new MetadataSearchKey("LastModified", MetadataSearchDatatype.datetime),


### PR DESCRIPTION
* ignore testDeleteObjectPreconditions() in encryption tests (preconditions will fail due to MD update from encryption client)
* getBucketLifecycle() now detects "NoSuchLifecyclePolicy" error code (this was corrected in ECS 3.8 from "NoSuchBucketPolicy" in prior versions)