### PR TITLE
Update Readme.md to clarify Java support versions more clearly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ Current APIs:
 
 - S3
 
-Targeted for Java 8+
+Targeted for Java 8, 11
 
 **As of the client version 3.2, read timeout is disabled by default to avoid conflicts in updating.**
 


### PR DESCRIPTION
Some customer is asking for Java 17 support. However Java SDK will not plan until ECS officially supports version 17.